### PR TITLE
Fix product id length

### DIFF
--- a/db/gmp-schema.sql
+++ b/db/gmp-schema.sql
@@ -80,7 +80,7 @@ DROP TABLE IF EXISTS `product`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `product` (
-  `id` varchar(80) NOT NULL,
+  `id` varchar(128) NOT NULL,
   `LAST_UPDATE` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `producttype` varchar(8) DEFAULT NULL,
   `orbit` int(6) DEFAULT NULL,

--- a/web/product.php
+++ b/web/product.php
@@ -2328,9 +2328,9 @@
                 $customText = '<div class="queue_dwnstatus_value" style="display: none;">'.$fieldData.'</div>';
                 $customText .= 
                 '<span class="queue_dwnstatus_caption" style="margin-right: 20px;">' . 
-                    ($fieldData == Q ? 'Queued' : 'None') . 
+                    ($fieldData == 'Q' ? 'Queued' : 'None') . 
                 '</span>';
-                if ($fieldData == N) {
+                if ($fieldData == 'N') {
                 $customText .= 
                 '<button onclick="' . 
                     "var dwnstatusValue = $(this).siblings('.queue_dwnstatus_value');" . 


### PR DESCRIPTION
Hello,

I've found an issue in GMP, I ran the pluginDhus.py to create the catalogue from an instance of the DHuS, but afterwards there was differences in the number of rows in tables product, files and queue.

![count of rows](http://i.imgur.com/Qhvqg2e.png)

The problem is caused by the length of the primary key `product.id` being too short (80 characters) while foreign keys in tables `files` and `queue` are 128 characters long.
Resulting in some product having their identifiers truncated in table `product` and missing from the two other tables.

![truncated id](http://i.imgur.com/rMBRIHV.png)